### PR TITLE
Refactor: 여행 토크 사이드바 메뉴 상태관리 개선

### DIFF
--- a/src/app/(route)/travelTalk/_components/SideBarNav.tsx
+++ b/src/app/(route)/travelTalk/_components/SideBarNav.tsx
@@ -1,16 +1,7 @@
 "use client";
 import MenuButton from "@/components/common/menu/MenuButton";
 import SelectBox from "@/components/common/select/SelectBox";
-import { Dispatch, SetStateAction, memo, useEffect } from "react";
-
-interface PropsType {
-  selectedCityOption: string;
-  setSelectedCityOption: Dispatch<SetStateAction<string>>;
-  selectedCategoryMenu: string;
-  setSelectedCategoryMenu: Dispatch<SetStateAction<string>>;
-  selectedWriteMenu: string;
-  setSelectedWriteMenu: Dispatch<SetStateAction<string>>;
-}
+import { memo } from "react";
 
 const cityOption = [
   { key: 0, value: "전체" },
@@ -37,57 +28,28 @@ const writeOption = [
   { key: 2, value: "내가 쓴 댓글" },
 ];
 
-const SideBarNav = ({
-  selectedCityOption,
-  setSelectedCityOption,
-  selectedCategoryMenu,
-  setSelectedCategoryMenu,
-  selectedWriteMenu,
-  setSelectedWriteMenu,
-}: PropsType) => {
-  useEffect(() => {
-    if (selectedCategoryMenu !== "") {
-      setSelectedWriteMenu("");
-    }
-  }, [selectedCategoryMenu]);
-
-  useEffect(() => {
-    if (selectedWriteMenu !== "") {
-      setSelectedCategoryMenu("");
-    }
-  }, [selectedWriteMenu]);
-
+const SideBarNav = () => {
   return (
     <div>
       <div className="mb-[16px]">
         <SelectBox
           option={cityOption}
-          setSelectedOption={setSelectedCityOption}
+          uniqueKey="sideBarRegion"
           optionWidth="283px"
         />
       </div>
       <div className="mb-[16px]">
         <div className="w-[full] h-[auto] p-[16px] border border-gray-150 rounded-m">
-          <MenuButton
-            option={categoryOption}
-            selectedOption={selectedCategoryMenu}
-            setSelectedOption={setSelectedCategoryMenu}
-            isDefaultCheck={true}
-          />
+          <MenuButton option={categoryOption} />
         </div>
       </div>
       <div>
         <div className="w-[full] h-[auto] p-[16px] border border-gray-150 rounded-m">
-          <MenuButton
-            option={writeOption}
-            selectedOption={selectedWriteMenu}
-            setSelectedOption={setSelectedWriteMenu}
-            isDefaultCheck={false}
-          />
+          <MenuButton option={writeOption} />
         </div>
       </div>
     </div>
   );
 };
 
-export default memo(SideBarNav);
+export default SideBarNav;

--- a/src/app/(route)/travelTalk/detail/[postId]/page.tsx
+++ b/src/app/(route)/travelTalk/detail/[postId]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { use, useEffect, useState } from "react";
+import { useState } from "react";
 import SideBarNav from "../../_components/SideBarNav";
 import TravelTalkHeader from "../../_components/TravelTalkHeader";
 import Sticker from "@/components/common/Sticker";
@@ -13,10 +13,6 @@ import { GetTravelTalkDetailPostOptions } from "@/api/travelTalk/query-options";
 import useFormatTimeAgo from "@/hooks/useFormatTimeAgo";
 
 const TravelTalkListDetailPage = () => {
-  // SideBarNav 관련 상태
-  const [selectedCityOption, setSelectedCityOption] = useState<string>("");
-  const [selectedCategoryMenu, setSelectedCategoryMenu] = useState<string>("");
-  const [selectedWriteMenu, setSelectedWriteMenu] = useState<string>("");
   // 댓글 관련 상태
   const [comment, setComment] = useState<string>("");
   // 게시글 고유 번호
@@ -65,14 +61,7 @@ const TravelTalkListDetailPage = () => {
       </div>
       <div className="grid grid-cols-4 gap-[24px] pt-[120px]">
         <div className="col-span-1">
-          <SideBarNav
-            selectedCityOption={selectedCityOption}
-            setSelectedCityOption={setSelectedCityOption}
-            selectedCategoryMenu={selectedCategoryMenu}
-            setSelectedCategoryMenu={setSelectedCategoryMenu}
-            selectedWriteMenu={selectedWriteMenu}
-            setSelectedWriteMenu={setSelectedWriteMenu}
-          />
+          <SideBarNav />
         </div>
         <div className="col-span-3">
           <div className="border border-gray-150 box-border pt-[24px] pb-[0px] rounded-sm">

--- a/src/app/(route)/travelTalk/page.tsx
+++ b/src/app/(route)/travelTalk/page.tsx
@@ -8,44 +8,35 @@ import MyCommentTalkList from "./_components/MyCommentTalkList";
 import { UseQueryResult, useQuery } from "@tanstack/react-query";
 import { API_ENDPOINT } from "@/lib/backend-api/api-end-point";
 import { GetTravelTalkListOptions } from "@/api/travelTalk/query-options";
+import {
+  useTravelTalkCategoryStore,
+  useTravelTalkStore,
+} from "@/store/zustand/useTravelTalkStore";
 
-interface dataType {
-  sticker: string;
-  title: string;
-  content: string;
-  watch: string;
-  like: string;
-  nickname: string;
-  time: string;
-}
-
-interface commentDataType {
-  comment: string;
-  sticker: string;
-  title: string;
-  date: string;
-}
 const TravelTalk = () => {
   // TravelTalkHeader 관련 상태
   const [selectedFilter, setSelectedFilter] = useState<string>("최신순");
   // Pagination 관련 상태
   const [currentPage, setCurrentPage] = useState<number>(1); // 현재 선택된 페이지
   const itemsPerPage = 10; // 페이지별 아이템 수
-  // SideBarNav 관련 상태
-  const [selectedCityOption, setSelectedCityOption] = useState<string>("");
-  const [selectedCategoryMenu, setSelectedCategoryMenu] = useState<string>("");
-  const [selectedWriteMenu, setSelectedWriteMenu] = useState<string>("");
+  // sideBar 지역 전역상태
+  const { selectBoxStates } = useTravelTalkStore();
+  // sideBar 카테고리 전역상태
+  const { selectCategoryStates } = useTravelTalkCategoryStore();
+
   // api 호출
   const { data: getTravelTalkList }: UseQueryResult<any> = useQuery(
     GetTravelTalkListOptions({
       boardCategory:
-        selectedCategoryMenu === "전체글" ? "" : selectedCategoryMenu,
-      region: selectedCityOption === "전체" ? "" : selectedCityOption,
+        selectCategoryStates === "전체글" ? "" : selectCategoryStates,
+      region:
+        selectBoxStates["sideBarRegion"] === "전체"
+          ? ""
+          : selectBoxStates["sideBarRegion"],
       page: 0,
     })
   );
 
-  // 더미 데이터
   const ITEMS = Array.from(
     { length: getTravelTalkList && getTravelTalkList.content.length },
     (_, i) => `Item ${i + 1}`
@@ -63,20 +54,13 @@ const TravelTalk = () => {
       </div>
       <div className="grid grid-cols-4 gap-[24px] pt-[120px]">
         <div className="col-span-1">
-          <SideBarNav
-            selectedCityOption={selectedCityOption}
-            setSelectedCityOption={setSelectedCityOption}
-            selectedCategoryMenu={selectedCategoryMenu}
-            setSelectedCategoryMenu={setSelectedCategoryMenu}
-            selectedWriteMenu={selectedWriteMenu}
-            setSelectedWriteMenu={setSelectedWriteMenu}
-          />
+          <SideBarNav />
         </div>
         <div className="col-span-3">
-          {selectedWriteMenu !== "내가 쓴 댓글" ? (
+          {selectBoxStates["sideBarCategory"] !== "내가 쓴 댓글" ? (
             <TalkList
               data={getTravelTalkList && getTravelTalkList.content}
-              selectedWriteMenu={selectedWriteMenu}
+              selectedWriteMenu={selectBoxStates["sideBarCategory"]}
             />
           ) : (
             <MyCommentTalkList

--- a/src/app/(route)/travelTalk/write/page.tsx
+++ b/src/app/(route)/travelTalk/write/page.tsx
@@ -4,6 +4,7 @@ import TravelTalkHeader from "../_components/TravelTalkHeader";
 import { useEffect, useState } from "react";
 import InputBox from "@/components/common/input/InputBox";
 import Textarea from "@/components/common/input/Textarea";
+import { useTravelTalkStore } from "@/store/zustand/useTravelTalkStore";
 
 const cityOption = [
   { key: 1, value: "도쿄" },
@@ -23,18 +24,16 @@ const categoryOption = [
 ];
 
 const TravelTalkWrite = () => {
-  const [selectedCityOption, setSelectedCityOption] = useState<string>("");
-  const [selectedCategoryOption, setSelectedCategoryOption] =
-    useState<string>("");
   const [isActiveButton, setIsActiveButton] = useState<boolean>(false);
   const [titleValue, setTitleValue] = useState<string>("");
   const [contentValue, setContentValue] = useState<string>("");
   const [isFocused, setIsFocused] = useState<boolean>(false); // 포커스 상태 관리
+  const { selectBoxStates } = useTravelTalkStore();
 
   useEffect(() => {
     if (
-      selectedCityOption !== "" &&
-      selectedCategoryOption !== "" &&
+      selectBoxStates["writeReigon"] !== "" &&
+      selectBoxStates["writeCategory"] !== "" &&
       titleValue !== "" &&
       contentValue !== ""
     ) {
@@ -42,7 +41,7 @@ const TravelTalkWrite = () => {
     } else {
       setIsActiveButton(false);
     }
-  }, [selectedCityOption, selectedCategoryOption, titleValue, contentValue]);
+  }, [selectBoxStates, titleValue, contentValue]);
 
   return (
     <div className="pt-[72px]">
@@ -66,7 +65,7 @@ const TravelTalkWrite = () => {
             <div className="col-span-1">
               <SelectBox
                 option={cityOption}
-                setSelectedOption={setSelectedCityOption}
+                uniqueKey="writeRegion"
                 optionWidth="490px"
                 placeHolder="지역을 선택해 주세요."
               />
@@ -74,7 +73,7 @@ const TravelTalkWrite = () => {
             <div className="col-span-1">
               <SelectBox
                 option={categoryOption}
-                setSelectedOption={setSelectedCategoryOption}
+                uniqueKey="writeCategory"
                 optionWidth="490px"
                 placeHolder="카테고리를 선택해 주세요."
               />

--- a/src/components/common/menu/MenuButton.tsx
+++ b/src/components/common/menu/MenuButton.tsx
@@ -1,34 +1,19 @@
-import { Dispatch, SetStateAction, memo, useEffect } from "react";
+import { useTravelTalkCategoryStore } from "@/store/zustand/useTravelTalkStore";
+import { useRouter } from "next/navigation";
+import { memo } from "react";
 
 interface PropsType {
   option: {
     key: number;
     value: string;
   }[];
-  selectedOption?: string;
-  setSelectedOption?: Dispatch<SetStateAction<string>>;
-  isDefaultCheck?: boolean; // 초기 option의 첫번째 항목 선택 여부 플래그
 }
 
-const MenuButton = ({
-  option,
-  selectedOption,
-  setSelectedOption,
-  isDefaultCheck,
-}: PropsType) => {
-  /** 초기에 선택될 메뉴를 저장 */
-  useEffect(() => {
-    if (setSelectedOption && isDefaultCheck) {
-      setSelectedOption(option[0].value);
-    }
-  }, []);
-
-  /** 선택된 메뉴 set */
-  const handleSelectedMenu = (value: string) => {
-    if (setSelectedOption) {
-      setSelectedOption(value);
-    }
-  };
+const MenuButton = ({ option }: PropsType) => {
+  const router = useRouter();
+  // 카테고리 전역상태관리
+  const { selectCategoryStates, setSelectCategoryState } =
+    useTravelTalkCategoryStore();
 
   return (
     <>
@@ -37,11 +22,14 @@ const MenuButton = ({
           <div
             key={item.key}
             className={`w-full h-auto cursor-pointer pl-[20px] pr-[20px] pt-[10px] pb-[10px] ${
-              selectedOption === item.value ? "bg-gray-100" : "bg-white"
+              selectCategoryStates === item.value ? "bg-gray-100" : "bg-white"
             } rounded-sm flex gap-[16px] ${
               index !== option.length - 1 ? "mb-[10px]" : ""
             } hover:bg-gray-100 transition-all duration-300 ease-in-out`}
-            onClick={() => handleSelectedMenu(item.value)}
+            onClick={() => {
+              setSelectCategoryState(item.value);
+              router.push("/travelTalk");
+            }}
           >
             <div className="flex gap-[16px]">
               <div className="w-[28px] h-[28px] appearance-none bg-gray-150"></div>

--- a/src/components/common/select/SelectBox.tsx
+++ b/src/components/common/select/SelectBox.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Icon from "@/public/svgs/Icon";
+import { useTravelTalkStore } from "@/store/zustand/useTravelTalkStore";
 import { Dispatch, SetStateAction, useState, useEffect, memo } from "react";
 
 interface PropsType {
@@ -10,6 +11,7 @@ interface PropsType {
   setSelectedOption?: Dispatch<SetStateAction<string>>;
   optionWidth?: string;
   placeHolder?: string;
+  uniqueKey: string;
 }
 
 const SelectBox = ({
@@ -17,17 +19,22 @@ const SelectBox = ({
   setSelectedOption,
   optionWidth,
   placeHolder,
+  uniqueKey,
 }: PropsType) => {
   // 옵션 show/hide 플래그
   const [showOption, setShowOption] = useState<boolean>(false);
-  // 현재 선택된 옵션
-  const [currentOption, setCurrentOption] = useState<string>(option[0].value);
+  // 지역 전역상태관리
+  const { selectBoxStates, setSelectBoxState } = useTravelTalkStore();
+  // 현재 선택된 옵션 가져오기
+  const currentOption =
+    selectBoxStates[uniqueKey] || placeHolder || option[0].value;
 
   useEffect(() => {
-    if (placeHolder) {
-      setCurrentOption(placeHolder);
+    // 초기 상태 설정
+    if (!selectBoxStates[uniqueKey]) {
+      setSelectBoxState(uniqueKey, currentOption);
     }
-  }, []);
+  }, [uniqueKey, currentOption, setSelectBoxState, selectBoxStates]);
 
   /** 스크롤을 내리면 옵션 숨김 */
   useEffect(() => {
@@ -44,16 +51,18 @@ const SelectBox = ({
     };
   }, [showOption]);
 
+  /** option show/hide */
   const handleSelectBox = () => {
     setShowOption((prev) => !prev);
   };
 
+  /** 선택한 option 저장 함수 */
   const handleSelectedOption = (value: string) => {
+    // 전역 상태 업데이트
+    setSelectBoxState(uniqueKey, value);
+
     if (setSelectedOption) {
-      // 선택된 옵션 부모 컴포넌트에 전달
       setSelectedOption(value);
-      // 현재 선택된 옵션 저장
-      setCurrentOption(value);
     }
     setShowOption(false);
   };

--- a/src/store/zustand/useTravelTalkStore.ts
+++ b/src/store/zustand/useTravelTalkStore.ts
@@ -1,0 +1,35 @@
+import { create } from "zustand";
+ 
+interface MenuState {
+  selectBoxStates: Record<string, string>;
+  setSelectBoxState: (key: string, value: string) => void;
+}
+ 
+interface CategoryMenuState {
+  selectCategoryStates: string;
+  setSelectCategoryState: (value: string) => void;
+}
+ 
+/** 여행토크 셀렉박스 전역상태관리 */
+export const useTravelTalkStore = create<MenuState>((set) => ({
+  selectBoxStates: {
+    sideBarRegion: "전체",
+  },
+  setSelectBoxState: (key, value) =>
+    set((state) => ({
+      selectBoxStates: {
+        ...state.selectBoxStates,
+        [key]: value,
+      },
+    })),
+}));
+ 
+/** 여행토크 사이드바 카테고리 전역상태관리 */
+export const useTravelTalkCategoryStore = create<CategoryMenuState>((set) => ({
+  selectCategoryStates: "전체글",
+  setSelectCategoryState: (value) =>
+    set(() => ({
+      selectCategoryStates: value,
+    })),
+}));
+ 


### PR DESCRIPTION
- 기존 컴포넌트 내부 상태 관리를 `zustand` 전역 상태 관리로 변경
- 사이드바 메뉴 선택 상태를 전역적으로 공유하여 코드의 재사용성과 유지보수성 향상
- 상태 관리 로직 간소화 및 관련 코드 정리