### PR TITLE
Feat: 여행토크 지역 셀렉박스 초기값 '전체' -> '도쿄'로 변경

### DIFF
--- a/src/app/(route)/travelTalk/_components/SideBarNav.tsx
+++ b/src/app/(route)/travelTalk/_components/SideBarNav.tsx
@@ -4,7 +4,6 @@ import SelectBox from "@/components/common/select/SelectBox";
 import { memo } from "react";
 
 const cityOption = [
-  { key: 0, value: "전체" },
   { key: 1, value: "도쿄" },
   { key: 2, value: "오사카" },
   { key: 3, value: "교토" },

--- a/src/app/(route)/travelTalk/page.tsx
+++ b/src/app/(route)/travelTalk/page.tsx
@@ -41,10 +41,7 @@ const TravelTalk = () => {
     GetTravelTalkListOptions({
       boardCategory:
         selectCategoryStates === "전체글" ? "" : selectCategoryStates,
-      region:
-        selectBoxStates["sideBarRegion"] === "전체"
-          ? ""
-          : selectBoxStates["sideBarRegion"],
+      region: selectBoxStates["sideBarRegion"],
       sort:
         selectedFilter === "최신순"
           ? "new"

--- a/src/store/zustand/useTravelTalkStore.ts
+++ b/src/store/zustand/useTravelTalkStore.ts
@@ -18,7 +18,7 @@ interface PostDetailDataState {
 /** 여행토크 셀렉박스 전역상태관리 */
 export const useTravelTalkStore = create<MenuState>((set) => ({
   selectBoxStates: {
-    sideBarRegion: "전체",
+    sideBarRegion: "도쿄",
   },
   setSelectBoxState: (key, value) =>
     set((state) => ({


### PR DESCRIPTION
🔥 작업 내용 (필수)

- 여행토크 지역 셀렉박스 초기값 변경

🔥 수정 사항 (선택)

- 초기값 '전체' -> '도쿄'로 변경

🔥 코멘트 (자유롭게 적는 곳 - 선택)

-
